### PR TITLE
feat: add loading animation while page is loading

### DIFF
--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -1,14 +1,41 @@
-import { Slot, component$ } from "@builder.io/qwik";
-import { Link, type LinkProps } from "@builder.io/qwik-city";
+import { Slot, component$, useSignal, $, useTask$ } from "@builder.io/qwik";
+import { Link, useLocation, type LinkProps } from "@builder.io/qwik-city";
 import useLocaleLink from "./useLocaleLink";
 
 export default component$((props: LinkProps) => {
   const base = useLocaleLink();
   const href = `${base}${props.href}`;
 
+  const state = useSignal(false);
+  const location = useLocation();
+
+  // Reset the state when navigation is done.
+  useTask$(({ track }) => {
+    track(() => location.isNavigating);
+    if (!location.isNavigating) {
+      state.value = false;
+    }
+  });
+
+  // Set the state to true when the link is clicked.
+  const onClick = $(() => {
+    state.value = true;
+  });
+
   return (
-    <Link {...props} href={href}>
+    <Link
+      {...props}
+      href={href}
+      class={["relative", props.class ?? ""]}
+      onClick$={onClick}
+    >
       <Slot />
+      <span
+        class={[
+          "animate-expand absolute bottom-0 left-1/2 h-0.5 w-0 -translate-x-1/2 transform bg-primary",
+          location.isNavigating && state.value ? "absolute" : "hidden",
+        ]}
+      ></span>
     </Link>
   );
 });

--- a/src/global.css
+++ b/src/global.css
@@ -122,3 +122,18 @@ body {
 header {
   position: relative;
 }
+
+@keyframes expand {
+  0% {
+    width: 0%;
+  }
+  100% {
+    width: 100%;
+  }
+}
+
+@layer utilities {
+  .animate-expand {
+    animation: expand 3s ease-in-out infinite;
+  }
+}


### PR DESCRIPTION
# Pull Request

## 描述

當網路或裝置速度較慢時, 按下按鈕/連結會看起來沒有反應, 實際正在讀取需要的資源
因此在頁面切換的連結之中增加讀取動畫, 以表示頁面切換正在執行中

## 變更類型

請刪除不相關的類型

- [x] 新功能

## 如何測試

在 Chrome 開發人員工具中, 網路分頁使用限制 "快速3G網路" 並切換頁面, 可以看到讀取動畫
