### PR TITLE
fix: searchParams is null in useLocation, use workaround

### DIFF
--- a/src/routes/projects/filter.tsx
+++ b/src/routes/projects/filter.tsx
@@ -24,7 +24,8 @@ export default component$<FilterProps>((props) => {
   });
 
   const updateQueryParameters = $((seletedFilter: string[]) => {
-    const queryParameters = location.url.searchParams;
+    // Workaround for the issue that the query parameters are not extracted in useLocation
+    const queryParameters = new URLSearchParams(document.location.search);
     if (seletedFilter.length === 0) {
       queryParameters.delete(props.filterName);
       // Remove the query parameter if there are no filters selected
@@ -54,7 +55,8 @@ export default component$<FilterProps>((props) => {
   });
 
   const initQueryParameters = $(() => {
-    const queryParameters = location.url.searchParams;
+    // Workaround for the issue that the query parameters are not extracted in useLocation
+    const queryParameters = new URLSearchParams(document.location.search);
     const selectedFilters = queryParameters.get(props.filterName);
     if (selectedFilters) {
       const selectedFiltersArray = selectedFilters.split(",");

--- a/src/routes/projects/page-nav.tsx
+++ b/src/routes/projects/page-nav.tsx
@@ -3,7 +3,6 @@ import { component$, $, useOnDocument } from "@builder.io/qwik";
 import PageNextButton from "./page-next-button";
 import PagePrevButton from "./page-prev-button";
 import PageNumberButton from "./page-number-button";
-import { useLocation } from "@builder.io/qwik-city";
 
 type PageNavProps = {
   currentPage: any;
@@ -46,17 +45,18 @@ function generatePageNumbers(totalPage: number, currentPageValue: number) {
 
 export const PageNav = component$<PageNavProps>(
   ({ currentPage, itemsPerPage, totalItems }) => {
-    const location = useLocation();
     const totalPage = Math.ceil(totalItems / itemsPerPage);
 
     const updateQueryParameter = $(() => {
-      const queryParameters = location.url.searchParams;
+      // Workaround for the issue that the query parameters are not extracted in useLocation
+      const queryParameters = new URLSearchParams(document.location.search);
       queryParameters.set("page", currentPage.value.toString());
       window.history.replaceState({}, "", `?${queryParameters}`);
     });
 
     const initQueryParameter = $(() => {
-      const queryParameters = location.url.searchParams;
+      // Workaround for the issue that the query parameters are not extracted in useLocation
+      const queryParameters = new URLSearchParams(document.location.search);
       const page = queryParameters.get("page");
       if (page === null) {
         currentPage.value = 1;


### PR DESCRIPTION
# Pull Request

## 描述

Qwik API useLocation 無法在靜態頁面時取得 searchParams,  改為 document 中取得

- 相關 Issue
  - https://github.com/QwikDev/qwik/issues/4956
  - https://github.com/QwikDev/qwik/issues/4767


## 變更類型

- [x] Bug 修復

## 如何測試

建置為靜態網站後, 可以正常從取得 searchParams, 並設定篩選器與分頁

**測試環境**:

- 作業系統: MacOS
- 瀏覽器版本: Chrome 124.0.6367.208

