### PR TITLE
fix: page in query params is not update when filter changed

### DIFF
--- a/src/routes/projects/page-nav.tsx
+++ b/src/routes/projects/page-nav.tsx
@@ -3,6 +3,7 @@ import { component$, $, useOnDocument } from "@builder.io/qwik";
 import PageNextButton from "./page-next-button";
 import PagePrevButton from "./page-prev-button";
 import PageNumberButton from "./page-number-button";
+import { isBrowser } from "@builder.io/qwik/build";
 
 type PageNavProps = {
   currentPage: any;
@@ -100,7 +101,7 @@ export const PageNav = component$<PageNavProps>(
 
     const generatePageList = () => {
       const pages = generatePageNumbers(totalPage, currentPage.value);
-
+      isBrowser && updateQueryParameter();
       return pages.map((page, index) => (
         <PageNumberButton
           key={index}


### PR DESCRIPTION
# Pull Request

## 描述

左側篩選器變更，頁面數量也變更時．頁數沒有更新到網址
修正網址中的頁面數字沒有更新，篩選器內容變更時應該回到第ㄧ頁

## 變更類型

- [x] Bug 修復

## 如何測試

1.  進入專案一覽頁面
2. 點選頁碼 3, 網址上page會更新為 3
3. 點選任意篩選器項目
4. 網址上page應該更新為1

**測試環境**:

- 作業系統: MacOS
- 瀏覽器版本: Chrome 125.0.6422.142 
